### PR TITLE
Allow `yarn lint` without dotenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "postinstall": "prisma generate",
     "migrate-prod": "scripts/migrate.sh",
-    "lint": "next lint",
+    "lint": "SKIP_ENV_VALIDATION=1 next lint",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
Otherwise you get:

```
yarn run lint
yarn run v1.22.19
$ next lint
info  - Loaded env from /Users/aiden/src/kellybowlpickem/.env
❌ Invalid environment variables:
 WEBHOOK_SECRET: Required
 NEXTAUTH_SECRET: Required

error - Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error
file:///Users/aiden/src/kellybowlpickem/src/env/server.mjs:16
  throw new Error("Invalid environment variables");
```